### PR TITLE
Updated send-response to be more generic

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -22,7 +22,7 @@ console.warn(payload);
 
 const data = new URLSearchParams();
 data.append('SAMLResponse', toBase64(payload));
-data.append('RelayState', toBase64(`{"products":["flex"],"resource":"${redirectUrl}"}`));
+data.append('RelayState', toBase64(redirectUrl));
 
 sendResponse(
   url,
@@ -31,10 +31,12 @@ sendResponse(
     maxRetry: 5,
     validateStatus: (status) => {
       console.log(`Response status: ${status}`);
-      return status === 303;
+      return status === 301;
     },
   },
   (response) => {
     console.log(`Response status: ${response}`);
   },
-);
+).then(res => {
+  console.log(`Response: ${res.data}`);
+})

--- a/src/core/response/send-response.ts
+++ b/src/core/response/send-response.ts
@@ -1,30 +1,18 @@
-import axios, { AxiosRequestConfig } from 'axios';
-import { SamlResponse } from '../../types';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { retryInterceptor } from '../helpers/axios';
-
-const extractJwt = (url: string): string => {
-  const re = new RegExp(/(?<=Token=).*/);
-  const match = url.match(re);
-
-  if (!match || !match[0]) {
-    throw new Error('Url does not contain JWT token');
-  }
-
-  return match[0];
-};
 interface SendResponseConfig {
   maxRetry?: number;
   maxRedirects?: number;
   validateStatus?: (status: number) => boolean;
 }
 
-export const sendResponse = async (
+export const sendResponse = async <T>(
   destinationUrl: string,
   data: unknown,
   config?: SendResponseConfig,
   retryCallBack?: (retryMessage: string) => void,
-): Promise<SamlResponse> => {
-  const interceptorId = axios.interceptors.response.use(
+): Promise<AxiosResponse<T>> => {
+  axios.interceptors.response.use(
     (res) => res,
     (err) => retryInterceptor(err, retryCallBack),
   );
@@ -50,11 +38,5 @@ export const sendResponse = async (
     data,
   };
 
-  const response: { data: { redirect_to: string } } = await axios(requestOptions);
-  axios.interceptors.response.eject(interceptorId);
-
-  return {
-    url: response.data.redirect_to,
-    jwt: extractJwt(response.data.redirect_to),
-  };
+  return axios(requestOptions);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,3 @@ export interface SamlOptions {
   attributes: Record<string, unknown>;
   username: string;
 }
-
-export interface SamlResponse {
-  url: string;
-  jwt: string;
-}


### PR DESCRIPTION
### Updated

- Demo's RelayState to be generic
- Updated status code match in Demo to 301
- Refactored send-response to be return a full generic axios response

### Removed

- Login to return redirect_url only
- Logic to extract JWT token